### PR TITLE
Added a link to the youtube generated RSS feed on the channels page

### DIFF
--- a/frontend/locales/en-US.toml
+++ b/frontend/locales/en-US.toml
@@ -67,6 +67,7 @@ videos = "Videos"
 playlists = "Playlists"
 shorts = "Shorts"
 livestreams = "Livestreams"
+rss = "RSS Feed"
 
 [playlist]
 videos = "%{video_count} videos"

--- a/frontend/src/pages/channel.rs
+++ b/frontend/src/pages/channel.rs
@@ -3,12 +3,13 @@ use invidious::{
 	CommonVideo,
 };
 use leptos::*;
-use leptos_router::create_query_signal;
+use leptos_router::{create_query_signal, NavigateOptions};
 use rustytube_error::RustyTubeError;
 
 use crate::{
 	components::{FerrisError, PlaceholderCardArray, PlaylistPreviewCard, VideoPreviewCard},
 	contexts::{LocaleCtx, ServerCtx, SubscriptionsCtx},
+	icons::SubscriptionsIcon,
 };
 
 #[derive(Clone)]
@@ -178,7 +179,12 @@ fn SubscribeBtn() -> impl IntoView {
 
 #[component]
 fn ContentCategoryButtons() -> impl IntoView {
+	let locale = expect_context::<LocaleCtx>().0 .0;
 	let content_category = expect_context::<RwSignal<ContentCategory>>();
+	let channel = expect_context::<Channel>();
+
+	let rss_href = format!("https://www.youtube.com/feeds/videos.xml?channel_id={}", channel.id);
+	let rss_text = move || t!("channel.rss", locale = &locale.get().id());
 
 	view! {
 		<div class="flex flex-row gap-x-3">
@@ -206,6 +212,13 @@ fn ContentCategoryButtons() -> impl IntoView {
 			>
 				Playlists
 			</button>
+			<a
+				href=rss_href
+				data-tip=rss_text
+				class="btn btn-outline btn-sm rounded-lg font-normal normal-case tooltip tooltip-info flex flex-row flex-nowrap space-x-2"
+			>
+				<SubscriptionsIcon/>
+			</a>
 		</div>
 	}
 }


### PR DESCRIPTION
In NewPipe, the channel page has a link to the channel's RSS feed (generated by youtube themselves). This PR adds that link to the channels page (re-using the existing subscriptions icon).

It looks like this:

![channel_rss](https://github.com/opensourcecheemsburgers/RustyTube/assets/4008299/1474eb8f-c4c3-412b-9b45-a270ac9c831c)